### PR TITLE
Positioning popup window based on sender window details

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -243,6 +243,7 @@ export class BrowserActionAPI {
         extensionId,
         session: this.store.session,
         parent: win,
+        sender: sender,
         url: popupUrl,
         anchorRect,
       })

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -188,17 +188,16 @@ export class PopupView {
         const window = BrowserWindow.fromWebContents(webcontents)
         if (window) {
           const winBounds = window.getBounds()
-          console.log(winBounds);
           this.anchorRect.x = this.anchorRect.x + winBounds.x
           this.anchorRect.y = this.anchorRect.y + winBounds.y
         }
       }
     }
 
-    const viewBounds = this.browserWindow.getBounds(); // TODO: support more orientations than just top-right
+    const viewBounds = this.browserWindow.getBounds() // TODO: support more orientations than just top-right
 
-    let x = this.anchorRect.x + this.anchorRect.width - viewBounds.width;
-    let y = this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING; // Convert to ints
+    let x = this.anchorRect.x + this.anchorRect.width - viewBounds.width
+    let y = this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING // Convert to ints
 
     // Convert to ints
     x = Math.floor(x)

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Session, webContents } from 'electron'
+import { BrowserWindow, Session, WebContents } from 'electron'
 
 const debug = require('debug')('electron-chrome-extensions:popup')
 
@@ -13,7 +13,7 @@ interface PopupViewOptions {
   extensionId: string
   session: Session
   parent: BrowserWindow
-  sender: webContents
+  sender: WebContents
   url: string
   anchorRect: PopupAnchorRect
 }
@@ -30,7 +30,7 @@ export class PopupView {
 
   browserWindow?: BrowserWindow
   parent?: BrowserWindow
-  sender?: webContents
+  sender?: WebContents
   extensionId: string
 
   private anchorRect: PopupAnchorRect
@@ -181,35 +181,37 @@ export class PopupView {
   private updatePosition() {
     if (!this.browserWindow || !this.sender) return
 
-    if (this.sender) {
-      const webcontents = webContents.fromId(this.sender.id)
+    let x, y, winBounds
 
-      if (webcontents) {
-        const window = BrowserWindow.fromWebContents(webcontents)
+    if (this.sender) {
+      const webContents =  WebContents.fromId(this.sender.id)
+
+      if (webContents) {
+        const window =  BrowserWindow.fromWebContents(webContents)
         if (window) {
-          const winBounds = window.getBounds()
-          this.anchorRect.x = this.anchorRect.x + winBounds.x
-          this.anchorRect.y = this.anchorRect.y + winBounds.y
+          winBounds = window.getBounds()
         }
       }
     }
 
-    const viewBounds = this.browserWindow.getBounds() // TODO: support more orientations than just top-right
+    const viewBounds = this.browserWindow.getBounds()
 
-    let x = this.anchorRect.x + this.anchorRect.width - viewBounds.width
-    let y = this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING // Convert to ints
+    if (winBounds) {
+      x = winBounds.x + this.anchorRect.x + this.anchorRect.width - viewBounds.width
+      y = winBounds.y + this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING // Convert to ints
 
-    // Convert to ints
-    x = Math.floor(x)
-    y = Math.floor(y)
+      // Convert to ints
+      x = Math.floor(x)
+      y = Math.floor(y)
 
-    debug(`updatePosition`, { x, y })
+      debug(`updatePosition`, { x, y })
 
-    this.browserWindow.setBounds({
-      ...this.browserWindow.getBounds(),
-      x,
-      y,
-    })
+      this.browserWindow.setBounds({
+        ...this.browserWindow.getBounds(),
+        x,
+        y,
+      })
+    }
   }
 
   /** Backwards compat for Electron <12 */


### PR DESCRIPTION
Currently the popup positions with respect to the parent. This PR is intended to position the popup based on the sender window.

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
